### PR TITLE
Remove reserved characters in description

### DIFF
--- a/blueprint/user-libraries/library-entries.mson
+++ b/blueprint/user-libraries/library-entries.mson
@@ -12,7 +12,7 @@
     + on_hold
     + planned
 + progress: 13 (number) - Current episode or chapter
-+ volumesOwned: 0 (number) - (Manga only)
++ volumesOwned: 0 (number) - Manga only
 + reconsuming: false (boolean)
 + reconsumeCount: 0 (number)
 + notes (nullable)


### PR DESCRIPTION
I noticed the attribute descriptions appeared to be missing on the [library entries page](http://docs.kitsu.apiary.io/#reference/user-libraries/library-entries) so I figured the use of [reserved characters](https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#61-characters) might be causing problems.