### PR TITLE
fix: library entries filter table

### DIFF
--- a/blueprint/filters/drama-id
+++ b/blueprint/filters/drama-id
@@ -1,1 +1,1 @@
-`dramaId`
+`dramaId` |

--- a/blueprint/filters/following
+++ b/blueprint/filters/following
@@ -1,1 +1,1 @@
-`following`
+`following` |


### PR DESCRIPTION
An attempt to fix the broken [filters table formatting](http://docs.kitsu.apiary.io/#reference/user-libraries/library-entries)