### PR TITLE
fix: update gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.* eol=lf
+* eol=lf


### PR DESCRIPTION
I think this should fix an issue I was having where the files in the [`blueprint/filters`](https://github.com/hummingbird-me/api-docs/tree/source/blueprint/filters) directory weren't using Unix line endings, causing the local tests to fail.